### PR TITLE
Use legacy middleware hooks

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -55,7 +55,7 @@
     }
   ],
   "dependencies": {
-    "fastboot-app-server": "dollarshaveclub/fastboot-app-server.git#middleware-hooks",
+    "fastboot-app-server": "dollarshaveclub/fastboot-app-server.git#legacy-middleware-hooks",
     "fastboot-watch-notifier": "2.1.0"
   }
 }


### PR DESCRIPTION
We will update this repo to use the new middleware hooks once they are merged into fastboot-app-server.
