### PR TITLE
Watch hack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,11 @@ ONBUILD RUN \
   rm -rf \
     ~/.ssh \
   && \
+  #
+  # TEMPORARY HACK to work around fastboot build issues
+  # - `ember build --watch` does not support dist/node-modules
+  #
+  mv /app/dist/node_modules /app/node_modules && \
   echo 'Done'
 
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,15 +93,13 @@ ONBUILD RUN \
     /tmp/* \
   && \
   #
-  # Cleanup apk
+  # Remove bulky SSL certs (880K)
   #
   rm -rf \
-    /etc/apk/* \
     /etc/ssl \
-    /lib/apk/* \
   && \
   #
-  # Cleanup Github SSH config
+  # Remove sensitive Github SSH credentials
   #
   rm -rf \
     ~/.ssh \

--- a/server/package.json
+++ b/server/package.json
@@ -56,6 +56,6 @@
   ],
   "dependencies": {
     "fastboot-app-server": "dollarshaveclub/fastboot-app-server.git#legacy-middleware-hooks",
-    "fastboot-watch-notifier": "2.1.0"
+    "fastboot-watch-notifier": "3.0.0"
   }
 }


### PR DESCRIPTION
SImilar to https://github.com/ember-fastboot/ember-cli-fastboot/pull/269, this works around the issues with `dist/node_modules` in the ember build process by falling back to `../node_modules`.

Updates `fastboot-watch-notifier` to remove `npm install`.
