### PR TITLE
Gzip

### DIFF
--- a/server/middleware/before-fastboot.js
+++ b/server/middleware/before-fastboot.js
@@ -16,5 +16,6 @@ function customMiddleware (req, res, next) {
 };
 
 module.exports = function (app) {
+  app.use(require('compression')());
   app.use('/*', customMiddleware);
 };

--- a/server/server.js
+++ b/server/server.js
@@ -21,7 +21,6 @@ const server = new FastBootAppServer({
   distPath,
   notifier,
   staticAssetOptions,
-  gzip: true,
   beforeMiddleware,
   afterMiddleware,
   workerCount,

--- a/test/docker-container-test.js
+++ b/test/docker-container-test.js
@@ -47,7 +47,7 @@ describe("dollarshaveclub/fastboot", function() {
   });
 
   it("gzips responses", function () {
-    return request('http://127.0.0.1:3000/assets/fastboot-app.js')
+    return request('http://127.0.0.1:3000/test-route')
       .then(response => {
         expect(response.headers['content-encoding']).to.equal('gzip');
         expect(response.statusCode).to.equal(200);


### PR DESCRIPTION
This moves the `compression` middleware up so that it's called before our custom middleware. This gzips all responses, even when fastboot is disabled. See the failing smoke test here: https://github.com/dollarshaveclub/face-web/pull/2429